### PR TITLE
Add support for rad10

### DIFF
--- a/src/com/mantz_it/hackrf_android/Hackrf.java
+++ b/src/com/mantz_it/hackrf_android/Hackrf.java
@@ -539,6 +539,7 @@ public class Hackrf implements Runnable{
 			case 0: return "Jellybean";
 			case 1: return "Jawbreaker";
 			case 2: return "HackRF One";
+			case 3: return "rad1o";
 			default: return "INVALID BOARD ID";
 		}
 	}
@@ -924,6 +925,11 @@ public class Hackrf implements Runnable{
 		// The Jawbreaker doesn't support this command!
 		if(this.getBoardID() == 1) {		// == Jawbreaker
 			Log.w(logTag, "setAntennaPower: Antenna Power is not supported for HackRF Jawbreaker. Ignore.");
+			return false;
+		}
+		// The rad1o doesn't support this command!
+		if(this.getBoardID() == 3) {		// == rad1o
+			Log.w(logTag, "setAntennaPower: Antenna Power is not supported for rad1o. Ignore.");
 			return false;
 		}
 		if(this.sendUsbRequest(UsbConstants.USB_DIR_OUT, HACKRF_VENDOR_REQUEST_ANTENNA_ENABLE, 


### PR DESCRIPTION
This patch adds support for the [rad1o badge](http://rad1o.de/). It is compatible with the HackRF but does not support setting of antenna power.

If you accept this pull request it would also be absolutely awesome if you could create a new release of your amazing RFAnalyzer app, if possible till next Tuesday. Each participant of the Chaos Communication Camp gets a rad1o badge and it would be fantastic if SDR newbies (like me) could just use the RFAnalyzer from Play store or F-Droid.